### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.gitmodules
+.github
+__pycache__
+*.pyc
+.venv
+.tox
+.mypy_cache
+.ruff_cache
+.pytest_cache
+.DS_Store
+uv.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    POETRY_VIRTUALENVS_CREATE=false
+
+WORKDIR /app
+
+# CairoSVG runtime dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libcairo2 \
+    libffi8 \
+    libgdk-pixbuf-2.0-0 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libxml2 \
+    libxslt1.1 \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir poetry
+
+# Install deps first for better layer caching.
+COPY pyproject.toml poetry.lock ./
+COPY python-chess ./python-chess
+
+RUN poetry install --no-interaction --no-ansi
+
+# Copy app code + assets.
+COPY server.py ./
+COPY *.json ./
+COPY piece_png ./piece_png
+COPY LICENSE.txt README.md ./
+
+EXPOSE 8080
+
+CMD ["python", "server.py", "--bind", "0.0.0.0", "--port", "8080"]
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Requires Python and poetry:
 
 ```
 sudo apt-get install python3-dev libffi-dev libxml2-dev libxslt1-dev libcairo2
+git submodule update --init --recursive
 poetry install
 ```
 
@@ -18,6 +19,24 @@ Usage
 
 ```
 poetry run python server.py [--port 8080] [--bind 127.0.0.1]
+```
+
+Docker
+------
+
+Build and run:
+
+```
+git submodule update --init --recursive
+docker build -t web-boardimage .
+docker run --rm -p 8080:8080 web-boardimage
+```
+
+Or with compose:
+
+```
+git submodule update --init --recursive
+docker compose up --build
 ```
 
 HTTP API

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  web-boardimage:
+    build: .
+    ports:
+      - "8080:8080"

--- a/server.py
+++ b/server.py
@@ -211,7 +211,7 @@ class Service:
         except ValueError:
             raise aiohttp.web.HTTPBadRequest(reason="invalid squares")
 
-        flipped = request.query.get("orientation", "white") == "black"
+        orientation = chess.BLACK if request.query.get("orientation", "white") == "black" else chess.WHITE
 
         AFFIRMATIVE_STRS = [
             "1",
@@ -247,7 +247,7 @@ class Service:
             svg.board(
                 board,
                 coordinates=coordinates,
-                flipped=flipped,
+                orientation=orientation,
                 lastmove=lastmove,
                 check=check,
                 arrows=arrows,


### PR DESCRIPTION
Adds a Dockerfile + docker-compose.yml for running the service without local system dependency setup. Note: repository must be checked out with submodules () so the python-chess path dependency is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Dockerfile to build a Python-based container image.
  * Added .dockerignore to exclude VCS, Python caches, virtualenvs, test caches, and OS files.
  * Added docker-compose.yml for local service orchestration.
  * Updated a vendored dependency reference.

* **Documentation**
  * Updated README with Docker/Docker Compose build/run steps and submodule initialization.

* **New Features**
  * Board rendering now accepts an explicit orientation (black/white).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
