### PR TITLE
Stop passing flipped to chess.svg

### DIFF
--- a/server.py
+++ b/server.py
@@ -211,7 +211,7 @@ class Service:
         except ValueError:
             raise aiohttp.web.HTTPBadRequest(reason="invalid squares")
 
-        flipped = request.query.get("orientation", "white") == "black"
+        orientation = chess.BLACK if request.query.get("orientation", "white") == "black" else chess.WHITE
 
         AFFIRMATIVE_STRS = [
             "1",
@@ -247,7 +247,7 @@ class Service:
             svg.board(
                 board,
                 coordinates=coordinates,
-                flipped=flipped,
+                orientation=orientation,
                 lastmove=lastmove,
                 check=check,
                 arrows=arrows,


### PR DESCRIPTION
The python-chess fork no longer needs a compatibility parameter on chess.svg.board. Web-boardimage already has an orientation query param; map it to chess.WHITE/chess.BLACK and pass orientation directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated board orientation logic to use explicit orientation values instead of implicit boolean-based handling, improving code clarity and ensuring more reliable board display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->