### PR TITLE
Fix Docker build after removing piece_png

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,8 @@ RUN poetry install --no-interaction --no-ansi
 # Copy app code + assets.
 COPY server.py ./
 COPY *.json ./
-COPY piece_png ./piece_png
 COPY LICENSE.txt README.md ./
 
 EXPOSE 8080
 
 CMD ["python", "server.py", "--bind", "0.0.0.0", "--port", "8080"]
-

--- a/server.py
+++ b/server.py
@@ -98,7 +98,7 @@ def deduplicate_svg_attrs(svg_string: str) -> str:
     new_attrs = " ".join([f"{key}={value}" for key, value in attrs.items()])
     return re.sub(PAT, f"<svg {new_attrs}>", svg_string, count=1)
 
-PIECE_SETS = os.listdir(os.path.join(THIS_DIR, "piece_png"))
+PIECE_SETS = svg.available_piece_sets()
 
 
 def load_theme(name):


### PR DESCRIPTION
- Dockerfile: stop copying deleted piece_png/ directory
- server.py: derive PIECE_SETS from chess.svg.available_piece_sets()
- Bump python-chess submodule to include viewBox normalization + available_piece_sets (PR #2 merge commit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Optimized Docker container image by removing unnecessary resources
  - Updated internal dependencies to their latest versions

* **Refactor**
  - Enhanced piece set discovery mechanism for improved reliability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->