### PR TITLE
Expose in-process renderer API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.12.2 /uv /uvx /bin/
 
 # Install deps first for better layer caching.
 COPY pyproject.toml uv.lock ./
+COPY web_boardimage ./web_boardimage
 COPY python-chess ./python-chess
 
 RUN uv sync --locked --no-dev

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Usage
 uv run python server.py [--port 8080] [--bind 127.0.0.1]
 ```
 
+Python API
+----------
+
+For in-process rendering, use `web_boardimage.renderer.render_board_png()` or
+`render_piece_png()` instead of starting the HTTP service.
+
 Docker
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["uv_build>=0.9.18,<0.10.0"]
+build-backend = "uv_build"
+
 [project]
 name = "web-boardimage"
 version = "0.1.0"
@@ -9,7 +13,7 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp~=3.14.3",
-    "chess~=1.11.2",
+    "chess @ git+https://github.com/hyprchs/python-chess.git@3991629484aab14ae31ba6b64b719d0d8114ac54",
     "resvg_py==0.3.3",
 ]
 
@@ -22,6 +26,10 @@ dev = [
 [tool.pytest.ini_options]
 pythonpath = ["."]
 testpaths = ["tests"]
+
+[tool.uv.build-backend]
+module-name = ["web_boardimage"]
+module-root = "."
 
 [tool.uv.sources]
 chess = { path = "python-chess", editable = true }

--- a/server.py
+++ b/server.py
@@ -31,81 +31,17 @@ import chess.svg as svg
 import json
 import random
 import colorsys
-from collections import deque
-import re
-import resvg_py
+from web_boardimage.renderer import (
+    available_piece_sets,
+    render_board_svg,
+    render_piece_svg,
+    render_svg_to_png,
+)
 
 THIS_DIR = os.path.dirname(__file__)
 
 
-def render_svg_to_png(svg_data: str) -> bytes:
-    # CSS defines 96 pixels per inch; bundled piece SVGs use mm and pt sizes.
-    return resvg_py.svg_to_bytes(svg_string=svg_data, dpi=96)
-
-
-def split_not_in_quotes(
-    s: str, delim: str = " ", quotes: list[tuple[str, str]] | None = None
-) -> list[str]:
-    """
-    Split a string on a delimeter if the delimeter is not inside a pair of quotes.
-    """
-    if quotes is None:
-        quotes = [('"', '"'), ("'", "'")]
-
-    # Validate that the 'quotes' are all 1 character long
-    assert all(
-        len(q[0]) == 1 and len(q[1]) == 1 for q in quotes
-    ), "All quotes must be exactly 1 character long"
-
-    # Loop through the string and keep track of whether we are inside a quoted string using a stack
-    stack = deque()
-    splits = []
-    current_split = []
-
-    for char in s:
-        if not stack and char == delim:
-            splits.append("".join(current_split))
-            current_split = []
-        else:
-            current_split.append(char)
-
-        if stack and char == stack[-1]:
-            stack.pop()
-        elif not stack:
-            for open_quote, close_quote in quotes:
-                if char == open_quote:
-                    stack.append(close_quote)
-                    break
-
-    # Add the last split
-    if current_split:
-        splits.append("".join(current_split))
-
-    return splits
-
-
-def deduplicate_svg_attrs(svg_string: str) -> str:
-    """Deduplicate the attributes in the outer `<svg>` tag in the given SVG string."""
-
-    # We just want to match the very first <svg> opening tag, ex:
-    # <svg xmlns="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 45 45">
-    # Then we do a simple string manipulation to remove duplicate attributes
-    PAT = re.compile(r"<svg ?([^>]*)>")
-    svg_attrs = re.match(PAT, svg_string).group(1)
-
-    # We shouldn't assume the attributes' values are always the same even if the attribute names are the same.
-    # However, if there are two attributes with the same name, the one that will be used is the last one, so
-    # as we iterate through the attrs, we can always overwrite the previous value.
-    attrs = {}
-    for attr in split_not_in_quotes(svg_attrs):
-        key, value = attr.split("=", 1)
-        attrs[key] = value
-
-    # Reconstruct the attributes string
-    new_attrs = " ".join([f"{key}={value}" for key, value in attrs.items()])
-    return re.sub(PAT, f"<svg {new_attrs}>", svg_string, count=1)
-
-PIECE_SETS = svg.available_piece_sets()
+PIECE_SETS = available_piece_sets()
 DEFAULT_PIECE_SET = "cburnett"
 
 
@@ -252,19 +188,17 @@ class Service:
 
         piece_set = select_piece_set(request)
 
-        return deduplicate_svg_attrs(
-            svg.board(
-                board,
-                coordinates=coordinates,
-                orientation=orientation,
-                lastmove=lastmove,
-                check=check,
-                arrows=arrows,
-                squares=squares,
-                size=size,
-                colors=colors,
-                piece_set=piece_set,
-            )
+        return render_board_svg(
+            board,
+            coordinates=coordinates,
+            orientation=orientation,
+            lastmove=lastmove,
+            check=check,
+            arrows=arrows,
+            squares=squares,
+            size=size,
+            colors=colors,
+            piece_set=piece_set,
         )
 
     def make_piece_svg(self, request):
@@ -288,9 +222,7 @@ class Service:
         except ValueError:
             raise aiohttp.web.HTTPBadRequest(reason="piece is not a valid piece") from None
 
-        piece_svg = svg.piece(piece=piece, size=size, piece_set=piece_set)
-
-        return deduplicate_svg_attrs(piece_svg)
+        return render_piece_svg(piece=piece, size=size, piece_set=piece_set)
 
     async def render_piece_png(self, request):
         svg_data = self.make_piece_svg(request)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -7,8 +7,10 @@ from xml.etree import ElementTree
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+import chess
 from PIL import Image, ImageChops
 from server import Service
+from web_boardimage.renderer import render_board_png
 
 EMPTY_FEN = "8/8/8/8/8/8/8/8 w - - 0 1"
 PAWN_FEN = "8/8/8/8/4P3/8/8/8 w - - 0 1"
@@ -131,6 +133,20 @@ def test_cardinal_king_png_matches_reviewed_rendering():
     rendered = decode_png(png_data)
     assert rendered.size == (CARDINAL_KING_SIZE, CARDINAL_KING_SIZE)
     assert sha256(rendered.tobytes()).hexdigest() == CARDINAL_WHITE_KING_PIXELS_SHA256
+
+
+def test_renderer_accepts_custom_board_colors():
+    rendered = decode_png(
+        render_board_png(
+            chess.Board(EMPTY_FEN),
+            size=BOARD_SIZE,
+            coordinates=False,
+            colors={"square light": "#010203", "square dark": "#040506"},
+        )
+    )
+
+    assert rendered.getpixel((0, 0)) == (1, 2, 3, 255)
+    assert rendered.getpixel((SQUARE_SIZE, 0)) == (4, 5, 6, 255)
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -746,7 +746,7 @@ wheels = [
 [[package]]
 name = "web-boardimage"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "chess" },

--- a/web_boardimage/__init__.py
+++ b/web_boardimage/__init__.py
@@ -1,0 +1,1 @@
+"""In-process chess board rendering."""

--- a/web_boardimage/renderer.py
+++ b/web_boardimage/renderer.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from collections import deque
+import re
+from typing import Iterable, Mapping
+
+import chess
+import chess.svg as svg
+import resvg_py
+
+Arrow = svg.Arrow
+
+
+def available_piece_sets() -> list[str]:
+    return svg.available_piece_sets()
+
+
+def render_svg_to_png(svg_data: str) -> bytes:
+    # CSS defines 96 pixels per inch; bundled piece SVGs use mm and pt sizes.
+    return resvg_py.svg_to_bytes(svg_string=svg_data, dpi=96)
+
+
+def render_board_svg(
+    board: chess.BaseBoard | None = None,
+    *,
+    orientation: chess.Color = chess.WHITE,
+    lastmove: chess.Move | None = None,
+    check: chess.Square | None = None,
+    arrows: Iterable[svg.Arrow | tuple[chess.Square, chess.Square]] = (),
+    arrow_style: svg.ArrowStyle = "lichess",
+    squares: chess.IntoSquareSet | None = None,
+    size: int | None = None,
+    coordinates: bool = True,
+    colors: Mapping[str, str] | None = None,
+    piece_set: str | None = None,
+) -> str:
+    return _deduplicate_svg_attrs(
+        svg.board(
+            board,
+            orientation=orientation,
+            lastmove=lastmove,
+            check=check,
+            arrows=arrows,
+            arrow_style=arrow_style,
+            squares=squares,
+            size=size,
+            coordinates=coordinates,
+            colors=dict(colors or {}),
+            piece_set=piece_set,
+        )
+    )
+
+
+def render_board_png(
+    board: chess.BaseBoard | None = None,
+    **kwargs: object,
+) -> bytes:
+    return render_svg_to_png(render_board_svg(board, **kwargs))
+
+
+def render_piece_svg(
+    piece: chess.Piece,
+    *,
+    size: int | None = None,
+    piece_set: str | None = None,
+) -> str:
+    return _deduplicate_svg_attrs(svg.piece(piece, size=size, piece_set=piece_set))
+
+
+def render_piece_png(
+    piece: chess.Piece,
+    *,
+    size: int | None = None,
+    piece_set: str | None = None,
+) -> bytes:
+    return render_svg_to_png(render_piece_svg(piece, size=size, piece_set=piece_set))
+
+
+def _split_not_in_quotes(
+    value: str,
+    delimiter: str = " ",
+    quotes: list[tuple[str, str]] | None = None,
+) -> list[str]:
+    if quotes is None:
+        quotes = [('"', '"'), ("'", "'")]
+    if not all(len(open_quote) == len(close_quote) == 1 for open_quote, close_quote in quotes):
+        raise ValueError("All quotes must be exactly one character long")
+
+    stack: deque[str] = deque()
+    splits: list[str] = []
+    current: list[str] = []
+    for character in value:
+        if not stack and character == delimiter:
+            splits.append("".join(current))
+            current = []
+        else:
+            current.append(character)
+        if stack and character == stack[-1]:
+            stack.pop()
+        elif not stack:
+            for open_quote, close_quote in quotes:
+                if character == open_quote:
+                    stack.append(close_quote)
+                    break
+    if current:
+        splits.append("".join(current))
+    return splits
+
+
+def _deduplicate_svg_attrs(svg_string: str) -> str:
+    pattern = re.compile(r"<svg ?([^>]*)>")
+    match = pattern.match(svg_string)
+    if match is None:
+        raise ValueError("Expected an SVG opening tag")
+    attrs: dict[str, str] = {}
+    for attr in _split_not_in_quotes(match.group(1)):
+        key, value = attr.split("=", 1)
+        attrs[key] = value
+    new_attrs = " ".join(f"{key}={value}" for key, value in attrs.items())
+    return pattern.sub(f"<svg {new_attrs}>", svg_string, count=1)


### PR DESCRIPTION
Adds a packaged renderer for direct board/piece SVG and PNG rendering.

The HTTP service now delegates to that path, and the wheel pins the fork that provides piece-set rendering.

Tests: Python 3.11–3.14 pytest; installed-wheel import/render check.