### PR TITLE
Expose board arrow style

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ name | type | default | description
 **lastMove** | string | *(none)* | The last move to highlight, e.g., `f4g6`
 **check** | string | *(none)* | A square to highlight for check, e.g., `h8`
 **arrows** | string | *(none)* | Draw arrows and circles, e.g., `Ge6g8,Bh7`, possible color prefixes: `G`, `B`, `R`, `Y`
+**arrowStyle** | string | `lichess` | Arrow geometry: `lichess` or `chess.com`
 **squares** | string | *(none)* | Marked squares, e.g., `a3,c3`
 **coordinates** | bool | *false* | Show a coordinate margin
 **colors** | string | lichess-brown | Theme: `wikipedia`, `lichess-brown`, `lichess-blue`, `random` (generate one on the fly)

--- a/server.py
+++ b/server.py
@@ -241,6 +241,9 @@ class Service:
         orientation = chess.BLACK if request.query.get("orientation", "white") == "black" else chess.WHITE
 
         coordinates = query_bool(request, "coordinates")
+        arrow_style = request.query.get("arrowStyle", "lichess")
+        if arrow_style not in ("lichess", "chess.com"):
+            raise aiohttp.web.HTTPBadRequest(reason="arrowStyle is not supported")
 
         try:
             if request.query.get("colors") == "random":
@@ -260,6 +263,7 @@ class Service:
                 lastmove=lastmove,
                 check=check,
                 arrows=arrows,
+                arrow_style=arrow_style,
                 squares=squares,
                 size=size,
                 colors=colors,

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -134,10 +134,32 @@ def test_cardinal_king_png_matches_reviewed_rendering():
 
 
 @pytest.mark.parametrize(
+    ("arrow_style", "expected_class"),
+    [("lichess", "arrow lichess"), ("chess.com", "arrow chess-com")],
+)
+def test_board_svg_uses_requested_arrow_style(arrow_style, expected_class):
+    status, content_type, svg_data = get_response(
+        request_url(
+            "/board.svg",
+            fen=EMPTY_FEN,
+            size=BOARD_SIZE,
+            arrows="Ge2e4",
+            arrowStyle=arrow_style,
+        )
+    )
+
+    assert status == 200
+    assert content_type == "image/svg+xml"
+    root = ElementTree.fromstring(svg_data)  # noqa: S314 - local test-app response
+    assert any(element.attrib.get("class") == expected_class for element in root.iter())
+
+
+@pytest.mark.parametrize(
     ("path", "query"),
     [
         ("/board.svg", {}),
         ("/board.svg", {"fen": PAWN_FEN, "coordinates": "perhaps"}),
+        ("/board.svg", {"fen": PAWN_FEN, "arrowStyle": "unknown"}),
         ("/piece.png", {"piece": "X", "size": 180}),
         ("/piece.png", {"piece": "P", "size": 9}),
         ("/piece.png", {"piece": "P", "size": 180, "pieceSet": "unknown"}),


### PR DESCRIPTION
Expose the existing `chess.svg.board(..., arrow_style=...)` control through the HTTP board endpoints as `arrowStyle`.

Includes API documentation and coverage for both supported styles plus invalid input.

Verification: `uv run pytest -q`.