### PR TITLE
Add Chess.com board theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ name | type | default | description
 **arrowStyle** | string | `lichess` | Arrow geometry: `lichess` or `chess.com`
 **squares** | string | *(none)* | Marked squares, e.g., `a3,c3`
 **coordinates** | bool | *false* | Show a coordinate margin
-**colors** | string | lichess-brown | Theme: `wikipedia`, `lichess-brown`, `lichess-blue`, `random` (generate one on the fly)
+**colors** | string | lichess-brown | Theme: `wikipedia`, `lichess-brown`, `lichess-blue`, `chess-com`, `random` (generate one on the fly)
 **pieceSet** | string | `cburnett` | Optional piece set; see [supported piece sets](#supported-piece-sets)
 **avoidMono** | bool | *false* | Exclude `mono` when `pieceSet=random`
 

--- a/server.py
+++ b/server.py
@@ -139,7 +139,8 @@ def load_theme(name):
 
 
 THEMES = {
-    name: load_theme(name) for name in ["wikipedia", "lichess-blue", "lichess-brown"]
+    name: load_theme(name)
+    for name in ["wikipedia", "lichess-blue", "lichess-brown", "chess-com"]
 }
 
 

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -154,6 +154,25 @@ def test_board_svg_uses_requested_arrow_style(arrow_style, expected_class):
     assert any(element.attrib.get("class") == expected_class for element in root.iter())
 
 
+def test_board_svg_uses_chess_com_colors():
+    status, content_type, svg_data = get_response(
+        request_url(
+            "/board.svg",
+            fen=PAWN_FEN,
+            size=BOARD_SIZE,
+            lastMove="e3e4",
+            colors="chess-com",
+        )
+    )
+
+    assert status == 200
+    assert content_type == "image/svg+xml"
+    assert all(
+        color in svg_data
+        for color in (b"#ebecd0", b"#779556", b"#f5f682", b"#b9ca43")
+    )
+
+
 @pytest.mark.parametrize(
     ("path", "query"),
     [

--- a/themes/chess-com.json
+++ b/themes/chess-com.json
@@ -1,0 +1,6 @@
+{
+  "square light": "#ebecd0",
+  "square dark": "#779556",
+  "square light lastmove": "#f5f682",
+  "square dark lastmove": "#b9ca43"
+}


### PR DESCRIPTION
Adds the named `colors=chess-com` palette and verifies its SVG output.