### PR TITLE
Expose renderer-authored board overlay annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ name | type | default | description
 **squares** | string | *(none)* | Marked squares, e.g., `a3,c3`
 **coordinates** | bool | *false* | Show a coordinate margin
 **colors** | string | lichess-brown | Theme: `wikipedia`, `lichess-brown`, `lichess-blue`, `chess-com`, `random` (generate one on the fly)
-**colorSeed** | int | *(none)* | Make `colors=random` deterministic for a given seed
+**randomSeed** | int | *(none)* | Make all randomized choices deterministic for a given seed
 **pieceSet** | string | `cburnett` | Optional piece set; see [supported piece sets](#supported-piece-sets)
 **avoidMono** | bool | *false* | Exclude `mono` when `pieceSet=random`
 
@@ -72,6 +72,7 @@ name | type | default | description
 --- | --- | --- | ---
 **pieceSet** | string | `cburnett` | Optional piece set; see [supported piece sets](#supported-piece-sets)
 **avoidMono** | bool | *false* | Exclude `mono` when `pieceSet=random`
+**randomSeed** | int | *(none)* | Make all randomized choices deterministic for a given seed
 **piece** | char | required | Piece letter: `p`, `n`, `b`, `r`, `q`, `k` for pawn, knight, bishop, rook, queen, king; uppercase is white, lowercase is black
 **size** | int | required | The width and height of the bounding-box/image/square, from 10 through 1000 pixels inclusive
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ https://backscattering.de/web-boardimage/board.svg?fen=5r1k/1b4pp/3pB1N1/p2Pq2Q/
 
 Accepts the same query parameters as `/board.svg`.
 
-### `GET /board.annotations.json` return overlay annotations
+**`GET /board.annotations.json` returns overlay annotations.**
 
 Accepts the same query parameters as `/board.svg`. Coordinates use the rendered
 image's pixel coordinate system. Arrow entries additionally include their anchor

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ name | type | default | description
 **squares** | string | *(none)* | Marked squares, e.g., `a3,c3`
 **coordinates** | bool | *false* | Show a coordinate margin
 **colors** | string | lichess-brown | Theme: `wikipedia`, `lichess-brown`, `lichess-blue`, `chess-com`, `random` (generate one on the fly)
+**colorSeed** | int | *(none)* | Make `colors=random` deterministic for a given seed
 **pieceSet** | string | `cburnett` | Optional piece set; see [supported piece sets](#supported-piece-sets)
 **avoidMono** | bool | *false* | Exclude `mono` when `pieceSet=random`
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ name | type | default | description
 **check** | string | *(none)* | A square to highlight for check, e.g., `h8`
 **arrows** | string | *(none)* | Draw arrows and circles, e.g., `Ge6g8,Bh7`, possible color prefixes: `G`, `B`, `R`, `Y`
 **arrowStyle** | string | `lichess` | Arrow geometry: `lichess` or `chess.com`
+**legalMoves** | string | *(none)* | Comma-separated legal UCI moves with one source square, e.g., `e2e4,e2e3`
+**legalMoveStyle** | string | `lichess` | Legal-destination geometry: `lichess` or `chess.com`
+**userHighlights** | string | *(none)* | Comma-separated `square:color:palette` values, e.g., `e4:green:lichess,d5:red:chess.com`
 **squares** | string | *(none)* | Marked squares, e.g., `a3,c3`
 **coordinates** | bool | *false* | Show a coordinate margin
 **colors** | string | lichess-brown | Theme: `wikipedia`, `lichess-brown`, `lichess-blue`, `chess-com`, `random` (generate one on the fly)
@@ -65,6 +68,37 @@ https://backscattering.de/web-boardimage/board.svg?fen=5r1k/1b4pp/3pB1N1/p2Pq2Q/
 ![example board image](https://backscattering.de/web-boardimage/board.svg?fen=5r1k/1b4pp/3pB1N1/p2Pq2Q/PpP5/6PK/8/8&lastMove=f4g6&check=h8&arrows=Ge6g8,Bh7&squares=a3,c3)
 
 ### `GET /board.png` render a PNG
+
+Accepts the same query parameters as `/board.svg`.
+
+### `GET /board.annotations.json` return overlay annotations
+
+Accepts the same query parameters as `/board.svg`. Coordinates use the rendered
+image's pixel coordinate system. Arrow entries additionally include their anchor
+box, ordered tail/head points, and oriented bounds.
+
+```json
+{
+  "width": 360,
+  "height": 360,
+  "overlays": [
+    {
+      "kind": "arrow",
+      "color": "green",
+      "bbox_xyxy": [178.332893, 201.279052, 219.289822, 297.023014],
+      "anchor_bbox_xyxy": [188.4375, 202.851562, 216.5625, 223.945312],
+      "tail_xy": [202.5, 292.5],
+      "head_xy": [202.5, 202.5],
+      "obb_xyxyxyxy": [
+        [219.289822, 205.30861],
+        [205.868202, 297.023014],
+        [178.332893, 292.993457],
+        [191.754514, 201.279052]
+      ]
+    }
+  ]
+}
+```
 
 ### `GET /piece.svg` and `/piece.png` render a piece
 

--- a/server.py
+++ b/server.py
@@ -318,6 +318,10 @@ class Service:
             }
             if annotation.color is not None:
                 payload["color"] = annotation.color
+            if annotation.anchor_bbox_xyxy is not None:
+                payload["anchor_bbox_xyxy"] = [
+                    round(value * scale, 6) for value in annotation.anchor_bbox_xyxy
+                ]
             if annotation.tail_xy is not None:
                 payload["tail_xy"] = [round(value * scale, 6) for value in annotation.tail_xy]
             if annotation.head_xy is not None:

--- a/server.py
+++ b/server.py
@@ -144,10 +144,10 @@ THEMES = {
 }
 
 
-def generate_random_color():
-    h = random.random()
-    s = random.uniform(0.5, 1.0)
-    v = random.uniform(0.5, 1.0)
+def generate_random_color(rng=random):
+    h = rng.random()
+    s = rng.uniform(0.5, 1.0)
+    v = rng.uniform(0.5, 1.0)
     return colorsys.hsv_to_rgb(h, s, v)
 
 
@@ -169,8 +169,8 @@ def shift_hue(color, shift):
     return colorsys.hsv_to_rgb(h, s, v)
 
 
-def generate_color_scheme():
-    light_square_color = generate_random_color()
+def generate_color_scheme(rng=random):
+    light_square_color = generate_random_color(rng)
     dark_square_color = adjust_brightness(
         light_square_color, 0.7
     )  # Darker than light square
@@ -274,7 +274,14 @@ class Service:
 
         try:
             if request.query.get("colors") == "random":
-                colors = generate_color_scheme()
+                color_seed = request.query.get("colorSeed")
+                try:
+                    rng = random.Random(int(color_seed)) if color_seed is not None else random
+                except ValueError:
+                    raise aiohttp.web.HTTPBadRequest(
+                        reason="colorSeed must be an integer"
+                    ) from None
+                colors = generate_color_scheme(rng)
             else:
                 colors = THEMES[request.query.get("colors", "lichess-brown")]
         except KeyError:

--- a/server.py
+++ b/server.py
@@ -193,7 +193,7 @@ def generate_color_scheme():
 
 
 class Service:
-    def make_svg(self, request):
+    def make_board_render(self, request):
         try:
             board = chess.Board(request.query["fen"])
         except KeyError:
@@ -231,6 +231,29 @@ class Service:
             raise aiohttp.web.HTTPBadRequest(reason="invalid arrow")
 
         try:
+            legal_moves = [
+                chess.Move.from_uci(value.strip())
+                for value in request.query.get("legalMoves", "").split(",")
+                if value.strip()
+            ]
+        except ValueError:
+            raise aiohttp.web.HTTPBadRequest(reason="legalMoves contains an invalid uci move")
+
+        try:
+            user_highlights = []
+            for token in request.query.get("userHighlights", "").split(","):
+                if not token.strip():
+                    continue
+                square_name, color, palette = token.strip().split(":")
+                user_highlights.append(
+                    svg.UserHighlight(chess.parse_square(square_name), color, palette)
+                )
+        except (TypeError, ValueError):
+            raise aiohttp.web.HTTPBadRequest(
+                reason="userHighlights must use square:color:palette tokens"
+            ) from None
+
+        try:
             squares = chess.SquareSet(
                 chess.parse_square(s.strip())
                 for s in request.query.get("squares", "").split(",")
@@ -245,6 +268,9 @@ class Service:
         arrow_style = request.query.get("arrowStyle", "lichess")
         if arrow_style not in ("lichess", "chess.com"):
             raise aiohttp.web.HTTPBadRequest(reason="arrowStyle is not supported")
+        legal_move_style = request.query.get("legalMoveStyle", "lichess")
+        if legal_move_style not in ("lichess", "chess.com"):
+            raise aiohttp.web.HTTPBadRequest(reason="legalMoveStyle is not supported")
 
         try:
             if request.query.get("colors") == "random":
@@ -256,8 +282,8 @@ class Service:
 
         piece_set = select_piece_set(request)
 
-        return deduplicate_svg_attrs(
-            svg.board(
+        try:
+            rendered = svg.board_with_annotations(
                 board,
                 coordinates=coordinates,
                 orientation=orientation,
@@ -269,8 +295,31 @@ class Service:
                 size=size,
                 colors=colors,
                 piece_set=piece_set,
+                legal_moves=legal_moves,
+                legal_move_style=legal_move_style,
+                user_highlights=user_highlights,
             )
-        )
+        except (TypeError, ValueError) as error:
+            raise aiohttp.web.HTTPBadRequest(reason=str(error)) from None
+        return rendered, size
+
+    def make_svg(self, request):
+        rendered, _ = self.make_board_render(request)
+        return deduplicate_svg_attrs(rendered.svg)
+
+    def make_annotations(self, request):
+        rendered, size = self.make_board_render(request)
+        scale = size / rendered.viewbox_size
+        overlays = []
+        for annotation in rendered.annotations:
+            payload = {
+                "kind": annotation.kind,
+                "bbox_xyxy": [round(value * scale, 6) for value in annotation.bbox_xyxy],
+            }
+            if annotation.color is not None:
+                payload["color"] = annotation.color
+            overlays.append(payload)
+        return {"width": size, "height": size, "overlays": overlays}
 
     def make_piece_svg(self, request):
         piece_set = select_piece_set(request)
@@ -322,6 +371,9 @@ class Service:
         png_data = await asyncio.to_thread(render_svg_to_png, svg_data)
         return aiohttp.web.Response(body=png_data, content_type="image/png")
 
+    async def render_annotations(self, request):
+        return aiohttp.web.json_response(self.make_annotations(request))
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
@@ -335,6 +387,7 @@ if __name__ == "__main__":
     service = Service()
     app.router.add_get("/board.png", service.render_png)
     app.router.add_get("/board.svg", service.render_svg)
+    app.router.add_get("/board.annotations.json", service.render_annotations)
     app.router.add_get("/piece.png", service.render_piece_png)
     app.router.add_get("/piece.svg", service.render_piece_svg)
 

--- a/server.py
+++ b/server.py
@@ -119,15 +119,22 @@ def query_bool(request, name, default=False):
         raise aiohttp.web.HTTPBadRequest(reason=f"{name} must be a boolean") from None
 
 
-def select_piece_set(request):
+def request_rng(request):
+    seed = request.query.get("randomSeed")
+    try:
+        return random.Random(int(seed)) if seed is not None else random
+    except ValueError:
+        raise aiohttp.web.HTTPBadRequest(reason="randomSeed must be an integer") from None
+
+
+def select_piece_set(request, rng=random):
     piece_set = request.query.get("pieceSet", DEFAULT_PIECE_SET)
     if piece_set == "random":
         if query_bool(request, "avoidMono"):
-            return random.choice([
-                piece_set_name for piece_set_name in PIECE_SETS
-                if piece_set_name != 'mono'
-            ])
-        return random.choice(PIECE_SETS)
+            return rng.choice(
+                [piece_set_name for piece_set_name in PIECE_SETS if piece_set_name != "mono"]
+            )
+        return rng.choice(PIECE_SETS)
     if piece_set not in PIECE_SETS:
         raise aiohttp.web.HTTPBadRequest(reason="invalid piece set")
     return piece_set
@@ -194,6 +201,7 @@ def generate_color_scheme(rng=random):
 
 class Service:
     def make_board_render(self, request):
+        rng = request_rng(request)
         try:
             board = chess.Board(request.query["fen"])
         except KeyError:
@@ -274,20 +282,13 @@ class Service:
 
         try:
             if request.query.get("colors") == "random":
-                color_seed = request.query.get("colorSeed")
-                try:
-                    rng = random.Random(int(color_seed)) if color_seed is not None else random
-                except ValueError:
-                    raise aiohttp.web.HTTPBadRequest(
-                        reason="colorSeed must be an integer"
-                    ) from None
                 colors = generate_color_scheme(rng)
             else:
                 colors = THEMES[request.query.get("colors", "lichess-brown")]
         except KeyError:
             raise aiohttp.web.HTTPBadRequest(reason="theme colors not found")
 
-        piece_set = select_piece_set(request)
+        piece_set = select_piece_set(request, rng)
 
         try:
             rendered = svg.board_with_annotations(
@@ -342,7 +343,7 @@ class Service:
         return {"width": size, "height": size, "overlays": overlays}
 
     def make_piece_svg(self, request):
-        piece_set = select_piece_set(request)
+        piece_set = select_piece_set(request, request_rng(request))
 
         try:
             raw_size = request.query.get("size")

--- a/server.py
+++ b/server.py
@@ -318,6 +318,10 @@ class Service:
             }
             if annotation.color is not None:
                 payload["color"] = annotation.color
+            if annotation.tail_xy is not None:
+                payload["tail_xy"] = [round(value * scale, 6) for value in annotation.tail_xy]
+            if annotation.head_xy is not None:
+                payload["head_xy"] = [round(value * scale, 6) for value in annotation.head_xy]
             overlays.append(payload)
         return {"width": size, "height": size, "overlays": overlays}
 

--- a/server.py
+++ b/server.py
@@ -322,6 +322,11 @@ class Service:
                 payload["tail_xy"] = [round(value * scale, 6) for value in annotation.tail_xy]
             if annotation.head_xy is not None:
                 payload["head_xy"] = [round(value * scale, 6) for value in annotation.head_xy]
+            if annotation.obb_xyxyxyxy is not None:
+                payload["obb_xyxyxyxy"] = [
+                    [round(coordinate * scale, 6) for coordinate in point]
+                    for point in annotation.obb_xyxyxyxy
+                ]
             overlays.append(payload)
         return {"width": size, "height": size, "overlays": overlays}
 

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -203,6 +203,8 @@ def test_board_annotations_are_renderer_authoritative_and_scaled_to_png():
     ]
     assert response["overlays"][2]["color"] == "red"
     assert response["overlays"][3]["color"] == "green"
+    assert response["overlays"][3]["tail_xy"] == [202.5, 292.5]
+    assert response["overlays"][3]["head_xy"] == [202.5, 202.5]
     for overlay in response["overlays"]:
         left, top, right, bottom = overlay["bbox_xyxy"]
         assert 0 <= left < right <= BOARD_SIZE

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -181,10 +181,10 @@ def test_random_board_colors_are_repeatable_with_a_seed():
 
     first = get_response(request_url("/board.svg", **query))
     second = get_response(request_url("/board.svg", **query))
-    different = get_response(request_url("/board.svg", **{**query, "randomSeed": 20260809}))
 
     assert first == second
-    assert first != different
+    assert b'fill="#5260ab"' in first[2]
+    assert b'fill="#394377"' in first[2]
 
 
 def test_random_board_colors_reject_an_invalid_seed():
@@ -218,7 +218,7 @@ def test_board_annotations_are_renderer_authoritative_and_scaled_to_png():
         "arrowStyle": "chess.com",
         "legalMoves": "e4d6,e4f6",
         "legalMoveStyle": "chess.com",
-        "userHighlights": "e4:red:lichess",
+        "userHighlights": "e4:red:chess.com",
     }
     status, content_type, payload = get_response(
         request_url("/board.annotations.json", **query)
@@ -238,6 +238,8 @@ def test_board_annotations_are_renderer_authoritative_and_scaled_to_png():
     assert response["overlays"][3]["color"] == "green"
     assert response["overlays"][3]["tail_xy"] == [202.5, 292.5]
     assert response["overlays"][3]["head_xy"] == [202.5, 202.5]
+    _, _, svg_data = get_response(request_url("/board.svg", **query))
+    assert b'class="user-highlight chess-com"' in svg_data
     anchor_bbox = response["overlays"][3]["anchor_bbox_xyxy"]
     assert anchor_bbox[3] - anchor_bbox[1] < BOARD_SIZE / 8
     arrow_obb = response["overlays"][3]["obb_xyxyxyxy"]

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -205,6 +205,9 @@ def test_board_annotations_are_renderer_authoritative_and_scaled_to_png():
     assert response["overlays"][3]["color"] == "green"
     assert response["overlays"][3]["tail_xy"] == [202.5, 292.5]
     assert response["overlays"][3]["head_xy"] == [202.5, 202.5]
+    arrow_obb = response["overlays"][3]["obb_xyxyxyxy"]
+    assert len(arrow_obb) == 4
+    assert all(len(point) == 2 for point in arrow_obb)
     for overlay in response["overlays"]:
         left, top, right, bottom = overlay["bbox_xyxy"]
         assert 0 <= left < right <= BOARD_SIZE

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from hashlib import sha256
 from io import BytesIO
 from urllib.parse import urlencode
@@ -12,6 +13,7 @@ from server import Service
 
 EMPTY_FEN = "8/8/8/8/8/8/8/8 w - - 0 1"
 PAWN_FEN = "8/8/8/8/4P3/8/8/8 w - - 0 1"
+LEGAL_HINT_FEN = "4k3/8/5p2/8/4N3/8/8/4K3 w - - 0 1"
 BOARD_SIZE = 360
 SQUARE_SIZE = BOARD_SIZE // 8
 DUBROVNY_PAWN_SIZE = 189
@@ -31,6 +33,7 @@ def create_test_app():
     service = Service()
     app.router.add_get("/board.png", service.render_png)
     app.router.add_get("/board.svg", service.render_svg)
+    app.router.add_get("/board.annotations.json", service.render_annotations)
     app.router.add_get("/piece.png", service.render_piece_png)
     app.router.add_get("/piece.svg", service.render_piece_svg)
     return app
@@ -171,6 +174,54 @@ def test_board_svg_uses_chess_com_colors():
         color in svg_data
         for color in (b"#ebecd0", b"#779556", b"#f5f682", b"#b9ca43")
     )
+
+
+def test_board_annotations_are_renderer_authoritative_and_scaled_to_png():
+    query = {
+        "fen": LEGAL_HINT_FEN,
+        "size": BOARD_SIZE,
+        "coordinates": "false",
+        "arrows": "Ge2e4",
+        "arrowStyle": "chess.com",
+        "legalMoves": "e4d6,e4f6",
+        "legalMoveStyle": "chess.com",
+        "userHighlights": "e4:red:lichess",
+    }
+    status, content_type, payload = get_response(
+        request_url("/board.annotations.json", **query)
+    )
+
+    assert status == 200
+    assert content_type == "application/json"
+    response = json.loads(payload)
+    assert response["width"] == response["height"] == BOARD_SIZE
+    assert [overlay["kind"] for overlay in response["overlays"]] == [
+        "legal_destination_dot",
+        "legal_destination_capture",
+        "user_highlight",
+        "arrow",
+    ]
+    assert response["overlays"][2]["color"] == "red"
+    assert response["overlays"][3]["color"] == "green"
+    for overlay in response["overlays"]:
+        left, top, right, bottom = overlay["bbox_xyxy"]
+        assert 0 <= left < right <= BOARD_SIZE
+        assert 0 <= top < bottom <= BOARD_SIZE
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        {"fen": PAWN_FEN, "legalMoveStyle": "unknown"},
+        {"fen": PAWN_FEN, "userHighlights": "e4:red"},
+        {"fen": PAWN_FEN, "legalMoves": "e2e4,d2d4"},
+        {"fen": PAWN_FEN, "legalMoves": "e2e5"},
+    ],
+)
+def test_board_annotations_reject_invalid_overlay_requests(query):
+    status, _, _ = get_response(request_url("/board.annotations.json", **query))
+
+    assert status == 400
 
 
 @pytest.mark.parametrize(

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -177,11 +177,11 @@ def test_board_svg_uses_chess_com_colors():
 
 
 def test_random_board_colors_are_repeatable_with_a_seed():
-    query = {"fen": EMPTY_FEN, "colors": "random", "colorSeed": 20260808}
+    query = {"fen": EMPTY_FEN, "colors": "random", "randomSeed": 20260808}
 
     first = get_response(request_url("/board.svg", **query))
     second = get_response(request_url("/board.svg", **query))
-    different = get_response(request_url("/board.svg", **{**query, "colorSeed": 20260809}))
+    different = get_response(request_url("/board.svg", **{**query, "randomSeed": 20260809}))
 
     assert first == second
     assert first != different
@@ -189,10 +189,24 @@ def test_random_board_colors_are_repeatable_with_a_seed():
 
 def test_random_board_colors_reject_an_invalid_seed():
     status, _, _ = get_response(
-        request_url("/board.svg", fen=EMPTY_FEN, colors="random", colorSeed="nope")
+        request_url("/board.svg", fen=EMPTY_FEN, colors="random", randomSeed="nope")
     )
 
     assert status == 400
+
+
+def test_random_piece_set_is_repeatable_with_the_request_seed():
+    query = {
+        "fen": PAWN_FEN,
+        "colors": "lichess-brown",
+        "pieceSet": "random",
+        "randomSeed": 20260808,
+    }
+
+    first = get_response(request_url("/board.svg", **query))
+    second = get_response(request_url("/board.svg", **query))
+
+    assert first == second
 
 
 def test_board_annotations_are_renderer_authoritative_and_scaled_to_png():

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -205,6 +205,8 @@ def test_board_annotations_are_renderer_authoritative_and_scaled_to_png():
     assert response["overlays"][3]["color"] == "green"
     assert response["overlays"][3]["tail_xy"] == [202.5, 292.5]
     assert response["overlays"][3]["head_xy"] == [202.5, 202.5]
+    anchor_bbox = response["overlays"][3]["anchor_bbox_xyxy"]
+    assert anchor_bbox[3] - anchor_bbox[1] < BOARD_SIZE / 8
     arrow_obb = response["overlays"][3]["obb_xyxyxyxy"]
     assert len(arrow_obb) == 4
     assert all(len(point) == 2 for point in arrow_obb)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -176,6 +176,25 @@ def test_board_svg_uses_chess_com_colors():
     )
 
 
+def test_random_board_colors_are_repeatable_with_a_seed():
+    query = {"fen": EMPTY_FEN, "colors": "random", "colorSeed": 20260808}
+
+    first = get_response(request_url("/board.svg", **query))
+    second = get_response(request_url("/board.svg", **query))
+    different = get_response(request_url("/board.svg", **{**query, "colorSeed": 20260809}))
+
+    assert first == second
+    assert first != different
+
+
+def test_random_board_colors_reject_an_invalid_seed():
+    status, _, _ = get_response(
+        request_url("/board.svg", fen=EMPTY_FEN, colors="random", colorSeed="nope")
+    )
+
+    assert status == 400
+
+
 def test_board_annotations_are_renderer_authoritative_and_scaled_to_png():
     query = {
         "fen": LEGAL_HINT_FEN,


### PR DESCRIPTION
Pins python-chess PR #5, forwards legal-move and highlight options, and exposes pixel-aligned overlay boxes plus ordered arrow endpoints from `/board.annotations.json`. The adapter does not redraw board-local primitives.

Tests: `.venv/bin/pytest -q tests/test_rendering.py`

Depends on hyprchs/python-chess#5.
