### PR TITLE
Bump reviewed python-chess overlay renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Accepts the same query parameters as `/board.svg`.
 **`GET /board.annotations.json` returns overlay annotations.**
 
 Accepts the same query parameters as `/board.svg`. Coordinates use the rendered
-image's pixel coordinate system. Arrow entries additionally include their anchor
-box, ordered tail/head points, and oriented bounds.
+image's pixel coordinate system. Arrow entries additionally include their
+arrowhead box, ordered tail/head points, and oriented bounds.
 
 ```json
 {
@@ -86,7 +86,7 @@ box, ordered tail/head points, and oriented bounds.
       "kind": "arrow",
       "color": "green",
       "bbox_xyxy": [178.332893, 201.279052, 219.289822, 297.023014],
-      "anchor_bbox_xyxy": [188.4375, 202.851562, 216.5625, 223.945312],
+      "arrowhead_bbox_xyxy": [188.4375, 202.851562, 216.5625, 223.945312],
       "tail_xy": [202.5, 292.5],
       "head_xy": [202.5, 202.5],
       "obb_xyxyxyxy": [

--- a/server.py
+++ b/server.py
@@ -326,9 +326,9 @@ class Service:
             }
             if annotation.color is not None:
                 payload["color"] = annotation.color
-            if annotation.anchor_bbox_xyxy is not None:
-                payload["anchor_bbox_xyxy"] = [
-                    round(value * scale, 6) for value in annotation.anchor_bbox_xyxy
+            if annotation.arrowhead_bbox_xyxy is not None:
+                payload["arrowhead_bbox_xyxy"] = [
+                    round(value * scale, 6) for value in annotation.arrowhead_bbox_xyxy
                 ]
             if annotation.tail_xy is not None:
                 payload["tail_xy"] = [round(value * scale, 6) for value in annotation.tail_xy]

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -240,8 +240,8 @@ def test_board_annotations_are_renderer_authoritative_and_scaled_to_png():
     assert response["overlays"][3]["head_xy"] == [202.5, 202.5]
     _, _, svg_data = get_response(request_url("/board.svg", **query))
     assert b'class="user-highlight chess-com"' in svg_data
-    anchor_bbox = response["overlays"][3]["anchor_bbox_xyxy"]
-    assert anchor_bbox[3] - anchor_bbox[1] < BOARD_SIZE / 8
+    arrowhead_bbox = response["overlays"][3]["arrowhead_bbox_xyxy"]
+    assert arrowhead_bbox[3] - arrowhead_bbox[1] < BOARD_SIZE / 8
     arrow_obb = response["overlays"][3]["obb_xyxyxyxy"]
     assert len(arrow_obb) == 4
     assert all(len(point) == 2 for point in arrow_obb)


### PR DESCRIPTION
## Summary

- advance the nested python-chess submodule from `bfe32735` to `b221264e`
- pick up exact rendered-primitive arrow AABBs and stronger overlay geometry tests
- keep custom-color Lichess arrows in the shared site-authentic opacity layer
- mirror Lichess's king-square and rook-square castling destinations
- expose renderer-neutral `arrowhead_bbox_xyxy` geometry
- retain the HTTP adapter as a pass-through to the python-chess renderer

## Dependency

Depends on hyprchs/python-chess#5 and pins its reviewed head commit:
https://github.com/hyprchs/python-chess/commit/b221264e414a698785f42d6f3a9750670c15f14e

This is the follow-up dependency bump after #20 was merged.

## Testing

- `./.venv/bin/pytest -q` — 23 passed
